### PR TITLE
feat: return User after inserting it into db

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,4 +36,4 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: make prepare_ci_db
       - run: cargo build --verbose
-      - run: cargo test --verbose
+      - run: cargo test -- --test-threads=1


### PR DESCRIPTION
Must run tests sequentially due to integration tests hitting the same Postgres service. For each test, we need to first run a full migration to guarantee the db is at the same exact state each time. This is suboptimal. I'll try to figure out a solution shortly. 